### PR TITLE
Fix: use default browser with open()

### DIFF
--- a/src/services/csgoempire.ts
+++ b/src/services/csgoempire.ts
@@ -195,8 +195,7 @@ export class CsgoempireService {
 										"tradeStatusSending"
 									);
 									await open(
-										`${tradeURL}&csgotrader_send=your_id_730_2_${assetIds.toString()}`,
-										{ app: "chrome" }
+										`${tradeURL}&csgotrader_send=your_id_730_2_${assetIds.toString()}`
 									);
 								} else {
 									await this.helperService.sendMessage(


### PR DESCRIPTION
Used to trigger the csgotrader app, currently, it specifically triggers with chrome instead of the users default browser.

Given how ram hungry chrome is, this feels like a poor choice as someone might use opera/brave/chromium/edge/etc