### PR TITLE
fix(steam): automatically sign back in and send notification when session expires

### DIFF
--- a/config.json
+++ b/config.json
@@ -42,6 +42,7 @@
 		"tradeStatusDodge": true,
 		"tradeStatusCanceled": true,
 		"steamOfferConfirmed": true,
-		"badResponse": true
+		"badResponse": true,
+		"steamSessionExpired": true,
 	}
 }

--- a/config.md
+++ b/config.md
@@ -43,7 +43,8 @@
         "tradeStatusDodge": true,
 		"tradeStatusCanceled": true,
         "steamOfferConfirmed": true,
-        "badResponse": true
+        "steamSessionExpired": true,
+        "badResponse": true,
     }
 }
 ```

--- a/src/@types/config.d.ts
+++ b/src/@types/config.d.ts
@@ -45,6 +45,7 @@ interface Notifications {
 	tradeStatusTimedOut: boolean;
 	tradeStatusDodge: boolean;
 	steamOfferConfirmed: boolean;
+	steamSessionExpired: boolean;
 	badResponse: boolean;
 }
 

--- a/src/services/helper.ts
+++ b/src/services/helper.ts
@@ -60,6 +60,9 @@ export class HelperService {
 		steamOfferConfirmed: {
 			color: this.colors.FgGreen,
 		},
+		steamSessionExpired: {
+			color: this.colors.FgRed,
+		},
 		badResponse: {
 			color: this.colors.FgRed,
 		},

--- a/src/services/steam.ts
+++ b/src/services/steam.ts
@@ -33,6 +33,7 @@ export class SteamService {
 						pollInterval: 120000,
 						// cancelTime: 9 * 60 * 1000, // cancel outgoing offers after 9mins
 					});
+
 					this.managers[config.steam.accountName].setCookies(
 						cookies,
 						function (err) {
@@ -42,6 +43,26 @@ export class SteamService {
 							}
 						}
 					);
+
+					this.steam.on('sessionExpired', async () => {
+						this.helperService.sendMessage(
+							`Steam session expired for ${config.steam.accountName}`,
+							"steamSessionExpired"
+						);
+
+						// Sign back in
+						let cookies = await this.login(config.steam);
+
+						this.managers[config.steam.accountName].setCookies(
+							cookies,
+							function (err) {
+								if (err) {
+									console.log(err);
+									return;
+								}
+							}
+						);
+					});
 
 					if (config.steam.acceptOffers) {
 						// Accepts all offers empty from our side

--- a/src/services/steam.ts
+++ b/src/services/steam.ts
@@ -32,6 +32,7 @@ export class SteamService {
 						language: "en",
 						pollInterval: 120000,
 						// cancelTime: 9 * 60 * 1000, // cancel outgoing offers after 9mins
+						community: this.steam,
 					});
 
 					this.managers[config.steam.accountName].setCookies(


### PR DESCRIPTION
I made this change in my own fork and worked pretty well, so thought I'd cherry-pick the commits and PR it here as well. Basically, we just try to sign back in via steam & set the cookies if the session has expired.

I'm trying to get rid of my fork now btw, so might spawn a PR or two here to get the changes I found helpful over here 👍